### PR TITLE
Fix endless redirects for /random in Safari

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,12 @@ fn index() -> Template {
 
 #[get("/random")]
 fn random() -> Redirect {
-    Redirect::to(&URI::percent_encode(&format!("::<{}>", random_type())))
+    // Safari doesn't seem to like redirect URLs starting with ::
+    // the leading / is here to fix that.
+    Redirect::to(&format!(
+        "/{}",
+        URI::percent_encode(&format!("::<{}>", random_type()))
+    ))
 }
 
 #[get("/<turbofish>")]


### PR DESCRIPTION
As previously reported by someone else in #5, https://turbo.fish/random doesn't work in Safari.
This is the case for both iOS and MacOS Safari:

![artboard](https://user-images.githubusercontent.com/4602612/47386869-19f80a00-d70e-11e8-91da-a12b6e9610f7.png)

Making the redirect URL absolute by prepending a `/` seems to do the trick.