### PR TITLE
Remove dynamic dispatch in random type generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +286,15 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -767,6 +782,7 @@ version = "0.1.0"
 dependencies = [
  "askama",
  "axum",
+ "itertools",
  "percent-encoding",
  "rand",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2018"
 [dependencies]
 askama = "0.10.5"
 axum = { version = "0.2.1", default-features = false }
+itertools = { version = "0.10.1", default-features = false }
 percent-encoding = "2.1.0"
 rand = "0.8.3"
 serde = "1.0.129"

--- a/src/random.rs
+++ b/src/random.rs
@@ -1,83 +1,50 @@
-use rand::seq::SliceRandom;
+use itertools::Itertools;
+use rand::{prelude::ThreadRng, seq::SliceRandom};
+use std::borrow::Cow;
 
 const RECURSION_LIMIT: u8 = 1;
 
-trait Type: Send + Sync {
-    fn num_generic_params(&self) -> usize;
-    fn stringify(&self, generic_params: &[String]) -> String;
-}
-
-impl Type for &'static str {
-    fn num_generic_params(&self) -> usize {
-        0
-    }
-
-    fn stringify(&self, _generic_params: &[String]) -> String {
-        (*self).to_owned()
-    }
-}
-
-impl Type for (&'static str, &'static str) {
-    fn num_generic_params(&self) -> usize {
-        1
-    }
-
-    fn stringify(&self, generic_params: &[String]) -> String {
-        format!("{}{}{}", self.0, generic_params[0], self.1)
-    }
-}
-
-impl Type for (&'static str, &'static str, &'static str) {
-    fn num_generic_params(&self) -> usize {
-        2
-    }
-
-    fn stringify(&self, generic_params: &[String]) -> String {
-        format!("{}{}{}{}{}", self.0, generic_params[0], self.1, generic_params[1], self.2)
-    }
-}
-
-static TYPES: &[&dyn Type] = &[
-    &"_",
-    &"bool",
-    &"char",
-    &"i8",
-    &"i16",
-    &"i32",
-    &"i64",
-    &"isize",
-    &"u8",
-    &"u16",
-    &"u32",
-    &"u64",
-    &"usize",
-    &"f32",
-    &"f64",
-    &"&str",
-    &"String",
-    &"()",
-    &("&", ""),
-    &("&mut ", ""),
-    &("[", "]"),
-    &("Box<", ">"),
-    &("Vec<", ">"),
-    &("HashSet<", ">"),
-    &("Result<", ", ", ">"),
-    &("HashMap<", ", ", ">"),
+const TYPES: &[&[&str]] = &[
+    &["_"],
+    &["bool"],
+    &["char"],
+    &["i8"],
+    &["i16"],
+    &["i32"],
+    &["i64"],
+    &["isize"],
+    &["u8"],
+    &["u16"],
+    &["u32"],
+    &["u64"],
+    &["usize"],
+    &["f32"],
+    &["f64"],
+    &["&str"],
+    &["String"],
+    &["()"],
+    &["&", ""],
+    &["&mut ", ""],
+    &["[", "]"],
+    &["Box<", ">"],
+    &["Vec<", ">"],
+    &["HashSet<", ">"],
+    &["Result<", ", ", ">"],
+    &["HashMap<", ", ", ">"],
 ];
 
 pub fn random_type() -> String {
-    random_type_depth(0)
+    random_type_depth(0, &mut rand::thread_rng())
 }
 
-fn random_type_depth(depth: u8) -> String {
-    let ty = TYPES.choose(&mut rand::thread_rng()).unwrap();
-
-    if depth == RECURSION_LIMIT {
-        ty.stringify(&(0..ty.num_generic_params()).map(|_| "_".to_owned()).collect::<Vec<_>>())
-    } else {
-        ty.stringify(
-            &(0..ty.num_generic_params()).map(|_| random_type_depth(depth + 1)).collect::<Vec<_>>(),
-        )
-    }
+fn random_type_depth(depth: u8, rng: &mut ThreadRng) -> String {
+    let &ty = TYPES.choose(rng).unwrap();
+    Itertools::intersperse_with(ty.iter().map(|&x| Cow::Borrowed(x)), || {
+        if depth == RECURSION_LIMIT {
+            "_".into()
+        } else {
+            random_type_depth(depth + 1, rng).into()
+        }
+    })
+    .collect()
 }


### PR DESCRIPTION
It's replaced with variable length slices which don't necessitate an implementation for each possible size.

This probably could be cleaner with `intersperse_with` (https://github.com/rust-lang/rust/issues/79524), but it's not stabilized yet.