### PR TITLE
Refactor: prefer `Box<str>` over `String`

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -27,16 +27,18 @@ pub async fn random_reverse() -> impl IntoResponse {
 #[derive(Template)]
 #[template(path = "turbofish.html")]
 struct TurboFishTpl {
-    guts: String,
-    guts_link: String,
+    guts: Box<str>,
+    guts_link: Box<str>,
     reverse: bool,
 }
 
 impl TurboFishTpl {
     fn new(turbofish: TurboFish) -> Self {
         Self {
-            guts: turbofish.guts.replace("<", "<\u{200B}"),
-            guts_link: utf8_percent_encode(&turbofish.guts, FRAGMENT).to_string(),
+            guts: turbofish.guts.replace("<", "<\u{200B}").into_boxed_str(),
+            guts_link: utf8_percent_encode(&turbofish.guts, FRAGMENT)
+                .collect::<String>()
+                .into_boxed_str(),
             reverse: turbofish.reverse,
         }
     }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -35,7 +35,7 @@ struct TurboFishTpl {
 impl TurboFishTpl {
     fn new(turbofish: TurboFish) -> Self {
         Self {
-            guts: turbofish.guts.replace("<", "<\u{200B}").into_boxed_str(),
+            guts: turbofish.guts.replace('<', "<\u{200B}").into_boxed_str(),
             guts_link: utf8_percent_encode(&turbofish.guts, FRAGMENT)
                 .collect::<String>()
                 .into_boxed_str(),

--- a/src/turbofish.rs
+++ b/src/turbofish.rs
@@ -11,7 +11,7 @@ pub struct TurboFish {
 }
 
 impl TurboFish {
-    pub fn new(guts: Box<str>) -> TurboFish {
+    pub const fn new(guts: Box<str>) -> TurboFish {
         TurboFish { guts, reverse: false }
     }
 
@@ -19,7 +19,7 @@ impl TurboFish {
         TurboFish::new(random_type().into_boxed_str())
     }
 
-    pub fn reverse(guts: Box<str>) -> TurboFish {
+    pub const fn reverse(guts: Box<str>) -> TurboFish {
         TurboFish { guts, reverse: true }
     }
 

--- a/src/turbofish.rs
+++ b/src/turbofish.rs
@@ -15,12 +15,12 @@ impl TurboFish {
         TurboFish { guts, reverse: false }
     }
 
-    pub fn random() -> TurboFish {
-        TurboFish::new(random_type().into_boxed_str())
-    }
-
     pub const fn reverse(guts: Box<str>) -> TurboFish {
         TurboFish { guts, reverse: true }
+    }
+
+    pub fn random() -> TurboFish {
+        TurboFish::new(random_type().into_boxed_str())
     }
 
     pub fn random_reverse() -> TurboFish {

--- a/src/turbofish.rs
+++ b/src/turbofish.rs
@@ -6,29 +6,29 @@ use serde::de::{self, Deserialize, Deserializer};
 use crate::{random::random_type, FRAGMENT};
 
 pub struct TurboFish {
-    pub guts: String,
+    pub guts: Box<str>,
     pub reverse: bool,
 }
 
 impl TurboFish {
-    pub fn new(guts: String) -> TurboFish {
+    pub fn new(guts: Box<str>) -> TurboFish {
         TurboFish { guts, reverse: false }
     }
 
     pub fn random() -> TurboFish {
-        TurboFish::new(random_type())
+        TurboFish::new(random_type().into_boxed_str())
     }
 
-    pub fn reverse(guts: String) -> TurboFish {
+    pub fn reverse(guts: Box<str>) -> TurboFish {
         TurboFish { guts, reverse: true }
     }
 
     pub fn random_reverse() -> TurboFish {
-        TurboFish::reverse(random_type())
+        TurboFish::reverse(random_type().into_boxed_str())
     }
 
     pub fn to_uri_segment(&self) -> String {
-        utf8_percent_encode(&self.to_string(), FRAGMENT).to_string()
+        utf8_percent_encode(&self.to_string(), FRAGMENT).collect()
     }
 }
 
@@ -46,11 +46,11 @@ fn parse(param: &str) -> Option<TurboFish> {
     match param.as_bytes().get(..3)? {
         b"::<" => {
             let mid = param[3..].strip_suffix('>')?;
-            Some(TurboFish::new(mid.to_owned()))
+            Some(TurboFish::new(mid.into()))
         }
         [b'<', ..] => {
             let mid = param[1..].strip_suffix(">::")?;
-            Some(TurboFish::reverse(mid.to_owned()))
+            Some(TurboFish::reverse(mid.into()))
         }
         _ => None,
     }


### PR DESCRIPTION
Looking through the code, I noticed that the `TurboFish` struct used the `String` type to contain text data. However, when following the usage of the `String` type, mutability is actually not necessary. All uses happen to be read-only. Therefore, I refactored the code a bit to prefer `Box<str>` over `String`, which has a considerably smaller memory footprint than `String`.[^footprint]

[^footprint]: First, a `Box<str>` is basically a pointer (`usize`). No need to store the `capacity` (as `String` would). [Excess capacity is also dropped.](https://doc.rust-lang.org/stable/std/string/struct.String.html#method.into_boxed_str)

Also, just for fun, I added a `const` declaration for some of the constructors for `TurboFish`. Although this technically has no effect today (since memory allocations are not _yet_ `const`), it doesn't hurt to have some forward-compatibility. 👍

Thanks!